### PR TITLE
Handle multiple author tags while parsing javadoc strings.

### DIFF
--- a/javalang/javadoc.py
+++ b/javalang/javadoc.py
@@ -10,7 +10,7 @@ class DocBlock(object):
         self.return_doc = None
         self.params = []
 
-        self.author = None
+        self.authors = []
         self.deprecated = False
 
         # @exception and @throw are equivalent
@@ -40,7 +40,7 @@ class DocBlock(object):
             self.return_doc = value
 
         elif name == 'author':
-            self.author = value
+            self.authors.append(value)
 
         elif name == 'deprecated':
             self.deprecated = True


### PR DESCRIPTION
I ran into a slight problem with this module while using [javasphinx](https://github.com/bronto/javasphinx) (which  depends on it).

According to the [Javadocs specification](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#@author):

> You can provide one @author tag, multiple @author tags, or no @author tags.

Currently, javalang will set the `author` value to the last author tag found. I would consider this a bug, since many java source files contain a list of author tags, and this list would be systematically suppressed by the current parser.

This patch fixes this problem, and allows multiple authors. I can also fix the downstream implementation in javasphinx, if that seems appropriate.
