### PR TITLE
parse_element_values always returns a list with only the last value

### DIFF
--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -736,7 +736,7 @@ class Parser(object):
 
             self.accept(',')
 
-        return element_value
+        return element_values
 
 # ------------------------------------------------------------------------------
 # -- Class body --


### PR DESCRIPTION
I've been playing around with TestNg annotations and I noticed that javalang has a small bug where parse_element_values correctly iterates through all of the elements and adds them to the list of element_values but instead of returning the list, it returns only the last element that was found.  e.g.:

```java
@Test(groups = {"groupA", "groupB"})
public void TestMethod() {}
```

for the code above an ElementValuePair Node is created with name="groups" and value having only a literal "groupB" instead of a list with both literals.

Instead of filing an issue I figured I would send a PR.