### PR TITLE
Add support for static and default methods in interfaces (Java 8)

### DIFF
--- a/javalang/test/test_java_8_syntax.py
+++ b/javalang/test/test_java_8_syntax.py
@@ -204,6 +204,36 @@ class MethodReferenceSyntaxTest(unittest.TestCase):
             parse.parse(setup_java_class("int[]::new;")))
 
 
+class InterfaceSupportTest(unittest.TestCase):
+
+    """ Contains tests for java 8 interface extensions. """
+
+    def test_interface_support_static_methods(self):
+        parse.parse("""
+interface Foo {
+    void foo();
+
+    static Foo create() {
+        return new Foo() {
+            @Override
+            void foo() {
+                System.out.println("foo");
+            }
+        };
+    }
+}
+        """)
+
+    def test_interface_support_default_methods(self):
+        parse.parse("""
+interface Foo {
+    default void foo() {
+        System.out.println("foo");
+    }
+}
+        """)
+
+
 def main():
     unittest.main()
 

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -43,9 +43,9 @@ class Keyword(JavaToken):
 
 
 class Modifier(Keyword):
-    VALUES = set(['abstract', 'final', 'native', 'private', 'protected',
-                  'public', 'static', 'strictfp', 'synchronized', 'transient',
-                  'volatile'])
+    VALUES = set(['abstract', 'default', 'final', 'native', 'private',
+                  'protected', 'public', 'static', 'strictfp', 'synchronized',
+                  'transient', 'volatile'])
 
 class BasicType(Keyword):
     VALUES = set(['boolean', 'byte', 'char', 'double',


### PR DESCRIPTION
Support defining static methods and default method implementations in interfaces.  This appears to be the only missing feature required for all my Java 8 code to parse correctly.

I guess the code could be simpler if it accepted implementations for all interface methods, but it seemed better to require them for static/default methods and reject them for other methods, which requires passing around the modifier set.