### PR TITLE
Allow interfaces to have an optional body, fix #30.

### DIFF
--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -1053,7 +1053,10 @@ class Parser(object):
         if self.try_accept('throws'):
             throws = self.parse_qualified_identifier_list()
 
-        self.accept(';')
+        if self.would_accept('{'):
+            body = self.parse_block()
+        else:
+            self.accept(';')
 
         return tree.MethodDeclaration(parameters=parameters,
                                       throws=throws,
@@ -1067,7 +1070,10 @@ class Parser(object):
         if self.try_accept('throws'):
             throws = self.parse_qualified_identifier_list()
 
-        self.accept(';')
+        if self.would_accept('{'):
+            body = self.parse_block()
+        else:
+            self.accept(';')
 
         return tree.MethodDeclaration(parameters=parameters,
                                       throws=throws)

--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -1049,6 +1049,7 @@ class Parser(object):
         parameters = self.parse_formal_parameters()
         array_dimension = self.parse_array_dimension()
         throws = None
+        body = None
 
         if self.try_accept('throws'):
             throws = self.parse_qualified_identifier_list()
@@ -1060,12 +1061,14 @@ class Parser(object):
 
         return tree.MethodDeclaration(parameters=parameters,
                                       throws=throws,
+                                      body=body,
                                       return_type=tree.Type(dimensions=array_dimension))
 
     @parse_debug
     def parse_void_interface_method_declarator_rest(self):
         parameters = self.parse_formal_parameters()
         throws = None
+        body = None
 
         if self.try_accept('throws'):
             throws = self.parse_qualified_identifier_list()
@@ -1076,7 +1079,8 @@ class Parser(object):
             self.accept(';')
 
         return tree.MethodDeclaration(parameters=parameters,
-                                      throws=throws)
+                                      throws=throws,
+                                      body=body)
 
     @parse_debug
     def parse_interface_generic_method_declarator(self):


### PR DESCRIPTION
This PR avoid a syntax error when parsing a java8 code with an interface containing a body, like:

```java
public interface Test{ default int foo() {return 0;} }
```

or

```java
public interface Test{ default void foo() {} }
```

This 2 codes works now. ref #30