### PR TITLE
Whithout package declaration, set the package name to 'default package'.

### DIFF
--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -285,8 +285,9 @@ class Parser(object):
             self.accept(';')
         else:
             self.tokens.pop_marker(True)
-            package_annotations = None
-
+            package = tree.PackageDeclaration(annotations=package_annotations,
+                                              name='default package',
+                                              documentation=javadoc)
         while self.would_accept('import'):
             import_declaration = self.parse_import_declaration()
             import_declarations.append(import_declaration)


### PR DESCRIPTION
If a file doesn't contain package declaration, a package is actually created, with the name `default package`.

The problem initially comes from [here](https://github.com/bronto/javasphinx/blob/master/javasphinx/compiler.py#L323) : I wanted to parse the test directory of a project but my test files didn't have package declaration, resulting a value Error.

I decided to PR on Javalang because in my opinion, set package to `None` is wrong, since every Java class have actually a package, although it can be unnamed.

Note: after merging this PR and release a new version, [this test](https://github.com/bronto/javasphinx/blob/master/javasphinx/compiler.py#L322) should be deleted on Javasphinx.