### PR TITLE
Add position information to nodes

### DIFF
--- a/javalang/ast.py
+++ b/javalang/ast.py
@@ -56,6 +56,11 @@ class Node(object):
     @property
     def children(self):
         return [getattr(self, attr_name) for attr_name in self.attrs]
+    
+    @property
+    def position(self):
+        if hasattr(self, "_position"):
+            return self._position
 
 def walk_tree(root):
     children = None


### PR DESCRIPTION
This adds position information for certain AST nodes.  It should help with issue #14; however, not all AST nodes have been addressed.  It maintains the private "_position" convention, but adds a property on the Node class to expose it publicly.