### PR TITLE
Fix IndexError when reading identifier at the end of a line

### DIFF
--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -1,0 +1,20 @@
+import unittest
+from .. import tokenizer
+
+
+class TestTokenizer(unittest.TestCase):
+
+    def test_tokenizer(self):
+
+        # Given
+        code = "    @Override"
+
+        # When
+        tokens = list(tokenizer.tokenize(code))
+
+        # Then
+        self.assertEqual(len(tokens), 2)
+        self.assertEqual(tokens[0].value, "@")
+        self.assertEqual(tokens[1].value, "Override")
+        self.assertEqual(type(tokens[0]), tokenizer.Annotation)
+        self.assertEqual(type(tokens[1]), tokenizer.Identifier)

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -416,7 +416,7 @@ class JavaTokenizer(object):
     def read_identifier(self):
         self.j = self.i + 1
 
-        while unicodedata.category(self.data[self.j]) in self.IDENT_PART_CATEGORIES:
+        while self.j < len(self.data) and unicodedata.category(self.data[self.j]) in self.IDENT_PART_CATEGORIES:
             self.j += 1
 
         ident = self.data[self.i:self.j]


### PR DESCRIPTION
This error happens with with annotation token.