### PR TITLE
Option to ignore errors on tokenization.

### DIFF
--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -43,3 +43,14 @@ class TestTokenizer(unittest.TestCase):
 
         # Then
         self.assertEqual(len(tokens), 11)
+
+    def test_tokenize_comment_line_with_period(self):
+
+        # Given
+        code = "   * all of the servlets resistant to cross-site scripting attacks."
+
+        # When
+        tokens = list(tokenizer.tokenize(code))
+
+        # Then
+        self.assertEqual(len(tokens), 13)

--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -51,9 +51,39 @@ class TestTokenizer(unittest.TestCase):
         # Then
         self.assertEqual(len(tokens), 13)
 
-    def test_tokenize_number_at_end(self):
+    def test_tokenize_integer_at_end(self):
         # Given
         code = "nextKey = new BlockKey(serialNo, System.currentTimeMillis() + 3"
+
+        # When
+        tokens = list(tokenizer.tokenize(code, ignore_errors=True))
+
+        # Then
+        self.assertEqual(len(tokens), 14)
+
+    def test_tokenize_float_at_end(self):
+        # Given
+        code = "nextKey = new BlockKey(serialNo, System.currentTimeMillis() + 3.0"
+
+        # When
+        tokens = list(tokenizer.tokenize(code, ignore_errors=True))
+
+        # Then
+        self.assertEqual(len(tokens), 14)
+
+    def test_tokenize_hex_integer_at_end(self):
+        # Given
+        code = "nextKey = new BlockKey(serialNo, System.currentTimeMillis() + 0x3"
+
+        # When
+        tokens = list(tokenizer.tokenize(code, ignore_errors=True))
+
+        # Then
+        self.assertEqual(len(tokens), 14)
+
+    def test_tokenize_hex_float_integer_at_end(self):
+        # Given
+        code = "nextKey = new BlockKey(serialNo, System.currentTimeMillis() + 0x3.2p2"
 
         # When
         tokens = list(tokenizer.tokenize(code, ignore_errors=True))

--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -5,7 +5,6 @@ from .. import tokenizer
 class TestTokenizer(unittest.TestCase):
 
     def test_tokenizer_annotation(self):
-
         # Given
         code = "    @Override"
 
@@ -20,7 +19,6 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(type(tokens[1]), tokenizer.Identifier)
 
     def test_tokenizer_javadoc(self):
-
         # Given
         code = "/**\n" \
                " * See {@link BlockTokenSecretManager#setKeys(ExportedBlockKeys)}\n" \
@@ -33,7 +31,6 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(len(tokens), 0)
 
     def test_tokenize_ignore_errors(self):
-
         # Given
         # character '#' was supposed to trigger an error of unknown token with a single line of javadoc
         code = " * See {@link BlockTokenSecretManager#setKeys(ExportedBlockKeys)}"
@@ -45,7 +42,6 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(len(tokens), 11)
 
     def test_tokenize_comment_line_with_period(self):
-
         # Given
         code = "   * all of the servlets resistant to cross-site scripting attacks."
 
@@ -54,3 +50,13 @@ class TestTokenizer(unittest.TestCase):
 
         # Then
         self.assertEqual(len(tokens), 13)
+
+    def test_tokenize_number_at_end(self):
+        # Given
+        code = "nextKey = new BlockKey(serialNo, System.currentTimeMillis() + 3"
+
+        # When
+        tokens = list(tokenizer.tokenize(code, ignore_errors=True))
+
+        # Then
+        self.assertEqual(len(tokens), 14)

--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -60,3 +60,16 @@ class TestTokenizer(unittest.TestCase):
 
         # Then
         self.assertEqual(len(tokens), 14)
+
+    def test_string_delim_within_comment(self):
+
+        # Given
+        code = "* Returns 0 if it can't find the end \
+                if (*itr == '\r') { \
+                        int status;"
+
+        # When
+        tokens = list(tokenizer.tokenize(code, ignore_errors=True))
+
+        # Then
+        self.assertEqual(len(tokens), 8)

--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -4,7 +4,7 @@ from .. import tokenizer
 
 class TestTokenizer(unittest.TestCase):
 
-    def test_tokenizer(self):
+    def test_tokenizer_annotation(self):
 
         # Given
         code = "    @Override"
@@ -18,3 +18,28 @@ class TestTokenizer(unittest.TestCase):
         self.assertEqual(tokens[1].value, "Override")
         self.assertEqual(type(tokens[0]), tokenizer.Annotation)
         self.assertEqual(type(tokens[1]), tokenizer.Identifier)
+
+    def test_tokenizer_javadoc(self):
+
+        # Given
+        code = "/**\n" \
+               " * See {@link BlockTokenSecretManager#setKeys(ExportedBlockKeys)}\n" \
+               " */"
+
+        # When
+        tokens = list(tokenizer.tokenize(code))
+
+        # Then
+        self.assertEqual(len(tokens), 0)
+
+    def test_tokenize_ignore_errors(self):
+
+        # Given
+        # character '#' was supposed to trigger an error of unknown token with a single line of javadoc
+        code = " * See {@link BlockTokenSecretManager#setKeys(ExportedBlockKeys)}"
+
+        # When
+        tokens = list(tokenizer.tokenize(code, ignore_errors=True))
+
+        # Then
+        self.assertEqual(len(tokens), 11)

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -146,8 +146,9 @@ class JavaTokenizer(object):
 
     IDENT_PART_CATEGORIES = set(['Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Mc', 'Mn', 'Nd', 'Nl', 'Pc', 'Sc'])
 
-    def __init__(self, data):
+    def __init__(self, data, ignore_errors=False):
         self.data = data
+        self.ignore_errors = ignore_errors
 
         self.current_line = 1
         self.start_of_line = 0
@@ -586,8 +587,7 @@ class JavaTokenizer(object):
             raise LexerError(message)
 
 def tokenize(code, ignore_errors=False):
-    tokenizer = JavaTokenizer(code)
-    tokenizer.ignore_errors = ignore_errors
+    tokenizer = JavaTokenizer(code, ignore_errors)
     return tokenizer.tokenize()
 
 def reformat_tokens(tokens):

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -535,7 +535,7 @@ class JavaTokenizer(object):
                 token_type = Annotation
                 self.j = self.i + 1
 
-            elif c == '.' and c_next.isdigit():
+            elif c == '.' and c_next and c_next.isdigit():
                 token_type = self.read_decimal_float_or_integer()
 
             elif self.try_separator():

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -193,6 +193,7 @@ class JavaTokenizer(object):
         while True:
             if j >= length:
                 self.error('Unterminated character/string literal')
+                break
 
             if state == 0:
                 if self.data[j] == '\\':

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -289,7 +289,7 @@ class JavaTokenizer(object):
 
         self.read_decimal_integer()
 
-        if self.data[self.j] not in '.eEfFdD':
+        if self.j >= len(self.data) or self.data[self.j] not in '.eEfFdD':
             return DecimalInteger
 
         if self.data[self.j] == '.':
@@ -345,7 +345,7 @@ class JavaTokenizer(object):
         tmp_i = 0
         c = None
 
-        while True:
+        while self.j + tmp_i < len(self.data):
             c = self.data[self.j + tmp_i]
 
             if c in digits:

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -556,6 +556,8 @@ class JavaTokenizer(object):
 
             else:
                 self.error('Could not process token', c)
+                self.i = self.i + 1
+                continue
 
             position = (self.current_line, self.i - self.start_of_line)
             token = token_type(self.data[self.i:self.j], position, self.javadoc)
@@ -579,10 +581,12 @@ class JavaTokenizer(object):
 
         message = u'%s at "%s", line %s: %s' % (message, char, line_number, line)
 
-        raise LexerError(message)
+        if not self.ignore_errors:
+            raise LexerError(message)
 
-def tokenize(code):
+def tokenize(code, ignore_errors=False):
     tokenizer = JavaTokenizer(code)
+    tokenizer.ignore_errors = ignore_errors
     return tokenizer.tokenize()
 
 def reformat_tokens(tokens):

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -297,16 +297,16 @@ class JavaTokenizer(object):
             self.i = self.j + 1
             self.read_decimal_integer()
 
-        if self.data[self.j] in 'eE':
+        if self.j < len(self.data) and self.data[self.j] in 'eE':
             self.j = self.j + 1
 
-            if self.data[self.j] in '-+':
+            if self.j < len(self.data) and self.data[self.j] in '-+':
                 self.j = self.j + 1
 
             self.i = self.j
             self.read_decimal_integer()
 
-        if self.data[self.j] in 'fFdD':
+        if self.j < len(self.data) and self.data[self.j] in 'fFdD':
             self.j = self.j + 1
 
         self.i = orig_i
@@ -318,25 +318,25 @@ class JavaTokenizer(object):
 
         self.read_hex_integer()
 
-        if self.data[self.j] not in '.pP':
+        if self.j >= len(self.data) or self.data[self.j] not in '.pP':
             return HexInteger
 
         if self.data[self.j] == '.':
             self.j = self.j + 1
             self.read_digits('0123456789abcdefABCDEF')
 
-        if self.data[self.j] in 'pP':
+        if self.j < len(self.data) and self.data[self.j] in 'pP':
             self.j = self.j + 1
         else:
             self.error('Invalid hex float literal')
 
-        if self.data[self.j] in '-+':
+        if self.j < len(self.data) and self.data[self.j] in '-+':
             self.j = self.j + 1
 
         self.i = self.j
         self.read_decimal_integer()
 
-        if self.data[self.j] in 'fFdD':
+        if self.j < len(self.data) and self.data[self.j] in 'fFdD':
             self.j = self.j + 1
 
         self.i = orig_i

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -149,6 +149,7 @@ class JavaTokenizer(object):
     def __init__(self, data, ignore_errors=False):
         self.data = data
         self.ignore_errors = ignore_errors
+        self.errors = []
 
         self.current_line = 1
         self.start_of_line = 0
@@ -582,9 +583,11 @@ class JavaTokenizer(object):
             char = self.data[self.j]
 
         message = u'%s at "%s", line %s: %s' % (message, char, line_number, line)
+        error = LexerError(message)
+        self.errors.append(error)
 
         if not self.ignore_errors:
-            raise LexerError(message)
+            raise error
 
 def tokenize(code, ignore_errors=False):
     tokenizer = JavaTokenizer(code, ignore_errors)


### PR DESCRIPTION
Option to ignore errors on tokenization. Useful when parsing snippets of code instead of complete block/files.