### PR TITLE
Allow line comments at the end of the file without a final line break

### DIFF
--- a/javalang/test/test_tokenizer.py
+++ b/javalang/test/test_tokenizer.py
@@ -41,6 +41,16 @@ class TestTokenizer(unittest.TestCase):
         # Then
         self.assertEqual(len(tokens), 11)
 
+    def test_tokenize_line_comment_eof(self):
+        # Given
+        code = "  // This line comment at the end of the file has no newline"
+
+        # When
+        tokens = list(tokenizer.tokenize(code))
+
+        # Then
+        self.assertEqual(len(tokens), 0)
+
     def test_tokenize_comment_line_with_period(self):
         # Given
         code = "   * all of the servlets resistant to cross-site scripting attacks."

--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -247,17 +247,19 @@ class JavaTokenizer(object):
 
     def read_comment(self):
         if self.data[self.i + 1] == '/':
-            terminator = '\n'
+            terminator, accept_eof = '\n', True
         else:
-            terminator = '*/'
+            terminator, accept_eof = '*/', False
 
         i = self.data.find(terminator, self.i + 2)
 
-        if i == -1:
+        if i != -1:
+            i += len(terminator)
+        elif accept_eof:
+            i = self.length
+        else:
             self.i = self.length
             return
-
-        i += len(terminator)
 
         comment = self.data[self.i:i]
         start_of_line = self.data.rfind('\n', self.i, i)


### PR DESCRIPTION
Fixes issue #61