### PR TITLE
Implement end_position for MethodDeclaration()

### DIFF
--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -1539,6 +1539,7 @@ class Parser(object):
                                      catches=catches,
                                      finally_block=finally_block)
             statement._position = token.position
+            statement._end_position = self.tokens.last().position
             return statement
 
         else:

--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -890,6 +890,7 @@ class Parser(object):
         return tree.MethodDeclaration(parameters=formal_parameters,
                                      throws=throws,
                                      body=body,
+                                     end_position=self.tokens.last().position,
                                      return_type=tree.Type(dimensions=additional_dimensions))
 
     @parse_debug
@@ -908,7 +909,8 @@ class Parser(object):
 
         return tree.MethodDeclaration(parameters=formal_parameters,
                                       throws=throws,
-                                      body=body)
+                                      body=body,
+                                      end_position=self.tokens.last().position)
 
     @parse_debug
     def parse_constructor_declarator_rest(self):
@@ -1086,6 +1088,7 @@ class Parser(object):
         return tree.MethodDeclaration(parameters=parameters,
                                       throws=throws,
                                       body=body,
+                                      end_position=self.tokens.last().position,
                                       return_type=tree.Type(dimensions=array_dimension))
 
     @parse_debug
@@ -1104,7 +1107,8 @@ class Parser(object):
 
         return tree.MethodDeclaration(parameters=parameters,
                                       throws=throws,
-                                      body=body)
+                                      body=body,
+                                      end_position=self.tokens.last().position)
 
     @parse_debug
     def parse_interface_generic_method_declarator(self):

--- a/javalang/parser.py
+++ b/javalang/parser.py
@@ -1537,9 +1537,9 @@ class Parser(object):
             statement = tree.TryStatement(resources=resource_specification,
                                      block=block,
                                      catches=catches,
+                                     end_position=self.tokens.last().position,
                                      finally_block=finally_block)
             statement._position = token.position
-            statement._end_position = self.tokens.last().position
             return statement
 
         else:
@@ -1584,7 +1584,11 @@ class Parser(object):
         self.accept(')')
         block = self.parse_block()
 
-        return tree.CatchClause(parameter=catch_parameter, block=block)
+        return tree.CatchClause(
+                        parameter=catch_parameter,
+                        block=block,
+                        end_position=self.tokens.last().position,
+                    )
 
     @parse_debug
     def parse_resource_specification(self):

--- a/javalang/tree.py
+++ b/javalang/tree.py
@@ -157,7 +157,7 @@ class SynchronizedStatement(Statement):
     attrs = ("lock", "block")
 
 class TryStatement(Statement):
-    attrs = ("resources", "block", "catches", "finally_block")
+    attrs = ("resources", "block", "catches", "finally_block", "end_position")
 
 class SwitchStatement(Statement):
     attrs = ("expression", "cases")
@@ -174,7 +174,7 @@ class TryResource(Declaration):
     attrs = ("type", "name", "value")
 
 class CatchClause(Statement):
-    attrs = ("parameter", "block")
+    attrs = ("parameter", "block", "end_position")
 
 class CatchClauseParameter(Declaration):
     attrs = ("types", "name")

--- a/javalang/tree.py
+++ b/javalang/tree.py
@@ -89,7 +89,8 @@ class Member(Documented):
     attrs = ()
 
 class MethodDeclaration(Member, Declaration):
-    attrs = ("type_parameters", "return_type", "name", "parameters", "throws", "body")
+    attrs = ("type_parameters", "return_type", "name", "parameters", "throws", "body",
+             "end_position")
 
 class FieldDeclaration(Member, Declaration):
     attrs = ("type", "declarators")


### PR DESCRIPTION
This change adds `end_position` attribute to MethodDeclaration() which is just position of last token in the method.