### PR TITLE
Fix a bug when tokenize an InfixExpression ends with a decimal number

### DIFF
--- a/javalang/tokenizer.py
+++ b/javalang/tokenizer.py
@@ -367,7 +367,9 @@ class JavaTokenizer(object):
         self.read_digits('01234567')
 
     def read_integer_or_float(self, c, c_next):
-        if c == '0' and c_next in 'xX':
+        if c_next is None:
+            return self.read_decimal_float_or_integer()
+        elif c == '0' and c_next in 'xX':
             return self.read_hex_integer_or_float()
         elif c == '0' and c_next in 'bB':
             self.read_bin_integer()


### PR DESCRIPTION
A bug occurs when I was trying to tokenize an infixExpression ends with a decimal number, and I tried to fix this problem.
```
Python 3.10.4 (main, Jan 25 2023, 00:13:50) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import javalang
>>> list(javalang.tokenizer.tokenize('a == 0'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/javalang/javalang/tokenizer.py", line 538, in tokenize
    token_type = self.read_integer_or_float(c, c_next)
  File "/workspaces/javalang/javalang/tokenizer.py", line 370, in read_integer_or_float
    if c == '0' and c_next in 'xX':
TypeError: 'in <string>' requires string as left operand, not NoneType
```